### PR TITLE
DEV: Improve logging for system commands

### DIFF
--- a/lib/minio_runner/mc_manager.rb
+++ b/lib/minio_runner/mc_manager.rb
@@ -8,13 +8,19 @@ module MinioRunner
       end
 
       def bucket_exists?(alias_name, name)
-        system(*command.concat(["ls", "#{alias_name}/#{name}"]))
+        system(
+          *command.concat(["ls", "#{alias_name}/#{name}"]),
+          out: MinioServerManager.log_file_path,
+        )
       end
 
       def create_bucket(alias_name, name)
         MinioRunner.logger.debug("Creating bucket #{alias_name}/#{name}...")
         if !bucket_exists?(alias_name, name)
-          system(*command.concat(["mb", "#{alias_name}/#{name}"]))
+          system(
+            *command.concat(["mb", "#{alias_name}/#{name}"]),
+            out: MinioServerManager.log_file_path,
+          )
           MinioRunner.logger.debug("Created  #{alias_name}/#{name}.")
         else
           MinioRunner.logger.debug("Bucket #{alias_name}/#{name} already exists, doing nothing.")
@@ -34,6 +40,7 @@ module MinioRunner
               MinioRunner.config.minio_root_password,
             ],
           ),
+          out: MinioServerManager.log_file_path,
         )
         MinioRunner.logger.debug("Set alias #{name} to #{url}.")
       end
@@ -42,7 +49,10 @@ module MinioRunner
         MinioRunner.logger.debug(
           "Setting anonymous access for #{alias_name}/#{bucket} to policy #{policy}...",
         )
-        system(*command.concat(["anonymous", "set", policy, "#{alias_name}/#{bucket}"]))
+        system(
+          *command.concat(["anonymous", "set", policy, "#{alias_name}/#{bucket}"]),
+          out: MinioServerManager.log_file_path,
+        )
         MinioRunner.logger.debug("Anonymous access set for #{alias_name}/#{bucket}.")
       end
     end

--- a/lib/minio_runner/minio_server_manager.rb
+++ b/lib/minio_runner/minio_server_manager.rb
@@ -18,6 +18,10 @@ module MinioRunner
         return if @server.nil?
         @server.stop
       end
+
+      def log_file_path
+        "#{MinioRunner.config.install_dir}/minio.log"
+      end
     end
 
     def start
@@ -38,7 +42,7 @@ module MinioRunner
             "MINIO_ROOT_PASSWORD" => MinioRunner.config.minio_root_password,
             "MINIO_DOMAIN" => MinioRunner.config.minio_domain,
           },
-          log_file: log_file_path,
+          log_file: MinioServerManager.log_file_path,
         )
 
       @process.start
@@ -79,10 +83,6 @@ module MinioRunner
       command << "--address #{MinioRunner.config.minio_domain}:#{MinioRunner.config.minio_port}"
 
       command
-    end
-
-    def log_file_path
-      "#{MinioRunner.config.install_dir}/minio.log"
     end
 
     def health_check(retries:)


### PR DESCRIPTION
Instead of logging system commands for mc calls to STDOUT,
it's better to just log them to the same place as the server
log, since they are mostly related to the minio server. This
will stop messages like this coming up in rspec output:

```
Added `local` successfully.
[2023-08-15 15:57:54 AEST]     0B optimized/
[2023-08-15 15:57:54 AEST]     0B original/
[2023-08-15 15:57:54 AEST]     0B temp/
Access permission for `local/discoursetest` is set to `public`
      uploads a file in the post composer
```
