### PR TITLE
DEV: Improve health check and add macOS specific errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    minio_runner (0.1.0)
+    minio_runner (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/minio_runner.rb
+++ b/lib/minio_runner.rb
@@ -39,12 +39,7 @@ module MinioRunner
             original_formatter = logger.formatter || Logger::Formatter.new
             logger.formatter =
               proc do |severity, time, progname, msg|
-                original_formatter.call(
-                  severity,
-                  time,
-                  progname,
-                  "[MinioRunner]: #{msg.strip.dump}",
-                )
+                original_formatter.call(severity, time, progname, "[MinioRunner]: #{msg.strip}")
               end
           end
     end

--- a/lib/minio_runner.rb
+++ b/lib/minio_runner.rb
@@ -7,6 +7,7 @@ require_relative "minio_runner/config"
 require_relative "minio_runner/minio_binary"
 require_relative "minio_runner/mc_binary"
 require_relative "minio_runner/binary_manager"
+require_relative "minio_runner/minio_health_check"
 require_relative "minio_runner/minio_server_manager"
 require_relative "minio_runner/mc_manager"
 

--- a/lib/minio_runner/minio_health_check.rb
+++ b/lib/minio_runner/minio_health_check.rb
@@ -21,8 +21,8 @@ module MinioRunner
             message =
               "Minio server failed to start after #{initial_retries + 1} attempts. Check that /etc/hosts is configured properly."
 
-            if MinioRunner::System.mac? && MinioRunner.config.minio_domain.ends_with?(".local")
-              message += Minio Runner::Network::MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE
+            if MinioRunner::System.mac? && MinioRunner.config.minio_domain.end_with?(".local")
+              message += "\n\n" + MinioRunner::Network::MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE
             end
 
             raise MinioRunner::Network::NetworkError.new(message)

--- a/lib/minio_runner/minio_health_check.rb
+++ b/lib/minio_runner/minio_health_check.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module MinioRunner
+  ##
+  # Checks that the minio server is running on the configured port using
+  # the /minio/health/live endpoint with a limited number of retries.
+  #
+  # Also used to check whether /etc/hosts is configured properly; some platforms
+  # (read: macOS) have to be configured in a certain way to avoid this.
+  class MinioHealthCheck
+    class << self
+      def call(retries: 2, initial_retries: nil)
+        initial_retries ||= retries
+        begin
+          Network.get("#{MinioRunner.config.minio_server_url}/minio/health/live")
+        rescue StandardError, MinioRunner::Network::NetworkError
+          if retries.positive?
+            sleep 1
+            call(retries: retries - 1, initial_retries: initial_retries)
+          else
+            message =
+              "Minio server failed to start after #{initial_retries + 1} attempts. Check that /etc/hosts is configured properly."
+
+            if MinioRunner::System.mac? && MinioRunner.config.minio_domain.ends_with?(".local")
+              message += Minio Runner::Network::MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE
+            end
+
+            raise MinioRunner::Network::NetworkError.new(message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/minio_runner/minio_server_manager.rb
+++ b/lib/minio_runner/minio_server_manager.rb
@@ -48,7 +48,7 @@ module MinioRunner
       @process.start
 
       # Make sure the minio server is ready to accept requests.
-      health_check(retries: 3)
+      MinioRunner::MinioHealthCheck.call(retries: 2)
 
       MinioRunner.logger.debug("minio server running at pid #{@process.pid}!")
     end
@@ -83,19 +83,6 @@ module MinioRunner
       command << "--address #{MinioRunner.config.minio_domain}:#{MinioRunner.config.minio_port}"
 
       command
-    end
-
-    def health_check(retries:)
-      begin
-        Network.get("#{MinioRunner.config.minio_server_url}/minio/health/live")
-      rescue StandardError
-        if retries.positive?
-          sleep 1
-          health_check(retries: retries - 1)
-        else
-          raise "Minio server failed to start."
-        end
-      end
     end
   end
 end

--- a/lib/minio_runner/network.rb
+++ b/lib/minio_runner/network.rb
@@ -77,7 +77,7 @@ module MinioRunner
       def log_time_error(request_start_time)
         if (Time.now - request_start_time) > Network::LONG_RESPONSE_TIME_SECONDS &&
              MinioRunner.config.minio_domain.end_with?(".local") && MinioRunner::System.mac?
-          MinioRunner.logger.warn(MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE.delete("\n"))
+          MinioRunner.logger.warn(MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE)
         end
       end
     end

--- a/lib/minio_runner/network.rb
+++ b/lib/minio_runner/network.rb
@@ -5,23 +5,59 @@ require "tempfile"
 
 module MinioRunner
   class Network
+    class NetworkError < StandardError
+    end
+
+    LONG_RESPONSE_TIME_SECONDS = 3
+    MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE = <<~END
+      For macOS, there are some issues which cause large delays for .local domain names. See
+      https://superuser.com/a/1297335/245469 and https://stackoverflow.com/a/17982964/875941. To
+      resolve this, you need to add IPV6 lookup addresses to the hosts file, and it helps to put
+      all the entries on one line.
+
+      ::1 minio.local testbucket.minio.local
+      fe80::1%lo0 minio.local testbucket.minio.local
+      127.0.0.1 minio.local testbucket.minio.local
+    END
+
     class << self
       def get(url)
         MinioRunner.logger.debug("Making network call to #{url}")
+        uri = URI(url)
+        response = nil
+        request_start_time = Time.now
 
         begin
-          response = Net::HTTP.get_response(URI(url))
-        rescue SocketError
-          raise "Can not reach #{url}"
+          Net::HTTP.start(
+            uri.host,
+            uri.port,
+            use_ssl: uri.scheme == "https",
+            read_timeout: 1,
+            open_timeout: 1,
+            write_timeout: 1,
+          ) { |http| response = http.get(uri.path) }
+        rescue SocketError, Net::OpenTimeout => err
+          MinioRunner.logger.debug(
+            "Connection error when checking minio server health: #{err.message}",
+          )
+          raise MinioRunner::Network::NetworkError.new(
+                  "Connection error, cannot reach URL: #{url} (#{err.class})",
+                )
         end
 
         MinioRunner.logger.debug("Get response: #{response.inspect}")
 
         case response
         when Net::HTTPSuccess
+          if (Time.now - request_start_time) > Network::LONG_RESPONSE_TIME_SECONDS &&
+               MinioRunner.config.minio_domain.ends_with?(".local") && MinioRunner::System.mac?
+            MinioRunner.logger.warn(MAC_OS_LOCAL_DOMAIN_ERROR_MESSAGE)
+          end
           response.body
         else
-          raise "#{response.class::EXCEPTION_TYPE}: #{response.code} \"#{response.message}\" with #{url}"
+          raise MinioRunner::Network::NetworkError.new(
+                  "#{response.class::EXCEPTION_TYPE}: #{response.code} \"#{response.message}\" with #{url}",
+                )
         end
       end
 

--- a/lib/minio_runner/version.rb
+++ b/lib/minio_runner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MinioRunner
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Adds detection and error messages for macOS specific .local
hosts file issues and general timeout error messaging for the
users to check their /etc/hosts file.
