### PR TITLE
FIX: Prevent attempting to stop if MinioRunner was never started

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    minio_runner (0.1.1)
+    minio_runner (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/minio_runner.rb
+++ b/lib/minio_runner.rb
@@ -13,6 +13,8 @@ require_relative "minio_runner/mc_manager"
 
 module MinioRunner
   class << self
+    @@started = false
+
     def config(&block)
       @config ||= MinioRunner::Config.new
       if block_given?
@@ -53,6 +55,12 @@ module MinioRunner
       setup_buckets
 
       logger.debug("Started minio_runner.")
+
+      @@started = true
+    end
+
+    def started?
+      @@started
     end
 
     def install_binaries
@@ -80,9 +88,11 @@ module MinioRunner
     end
 
     def stop
+      return if !started?
       logger.debug("Stopping minio_runner...")
       MinioRunner::MinioServerManager.stop
       logger.debug("Stopped minio_runner.")
+      @@started = false
     end
 
     def reset_config!

--- a/lib/minio_runner/version.rb
+++ b/lib/minio_runner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MinioRunner
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "minitest/reporters"
 require "pry"
 require "pry-byebug"
 require "spy/integration"
+require "date"
 
 # c.f. https://gist.github.com/jazzytomato/79bb6ff516d93486df4e14169f4426af
 def mock_env(partial_env_hash)

--- a/test/test_minio_runner_binary_manager.rb
+++ b/test/test_minio_runner_binary_manager.rb
@@ -71,7 +71,7 @@ class TestMinioBinaryManager < Minitest::Test
     end
 
     # cache is determined by the mtime of the version file
-    `touch -d "2 days ago" #{TestBinary.version_file_path}`
+    `touch -d "#{(DateTime.now - 3).strftime("%Y-%m-%dT%H:%M:00")}" #{TestBinary.version_file_path}`
 
     MinioRunner::Network.stub :get, NetworkGetStub do
       download_spy = Spy.on(MinioRunner::Network, :download)


### PR DESCRIPTION
We can tell whether MinioRunner was started, so we can prevent
unnecessary "Stopping minio_runner..." messages and process checking
if it never did. This allows consumers to call MinioRunner.stop
without worry in things like rspec after(:suite)
