### PR TITLE
Add `install` kwarg to `MinioRunner.start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ setup and teardown for rspec.
 # is greater than the installed version.
 MinioRunner.start
 
+# Start the server without attempting to locate or download the minio binary
+MinioRunner.start(install: false)
+
 # Stop the currently running server.
 MinioRunner.stop
 ```

--- a/lib/minio_runner.rb
+++ b/lib/minio_runner.rb
@@ -46,10 +46,10 @@ module MinioRunner
           end
     end
 
-    def start
+    def start(install: true)
       logger.debug("Starting minio_runner...")
 
-      install_binaries
+      install_binaries if install
       start_server
       setup_alias
       setup_buckets

--- a/lib/minio_runner/version.rb
+++ b/lib/minio_runner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MinioRunner
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
It is useful to be able to run `MinioRunner.start` without the overhead
of locating and downloading the minio binary in environments where the
binary is already downloaded.
