### PR TITLE
Allow overriding mc and minio binary urls in config

### DIFF
--- a/lib/minio_runner/config.rb
+++ b/lib/minio_runner/config.rb
@@ -3,6 +3,7 @@
 module MinioRunner
   class Config
     attr_accessor :cache_time, :buckets, :public_buckets, :log_level
+    attr_accessor :mc_binary_download_url, :minio_binary_download_url
     attr_accessor :minio_root_user,
                   :minio_root_password,
                   :minio_domain,
@@ -36,6 +37,8 @@ module MinioRunner
         "Password for minio server root user (default #{DEFAULT_MINIO_ROOT_PASSWORD})",
       minio_console_port: "Port for minio server console (default #{DEFAULT_MINIO_CONSOLE_PORT})",
       minio_port: "Port for minio server (default #{DEFAULT_MINIO_PORT})",
+      mc_binary_download_url: "Download url for mc binary",
+      minio_binary_download_url: "Download url for minio binary",
     }
 
     def initialize
@@ -51,6 +54,10 @@ module MinioRunner
       self.minio_domain = System.env(:minio_domain) || "localhost"
       self.minio_port = System.env(:minio_port) || DEFAULT_MINIO_PORT
       self.minio_console_port = System.env(:minio_console_port) || DEFAULT_MINIO_CONSOLE_PORT
+
+      # minio downloads configuration
+      self.mc_binary_download_url = System.env(:mc_binary_download_url)
+      self.minio_binary_download_url = System.env(:minio_binary_download_url)
     end
 
     def install_dir=(dir)

--- a/lib/minio_runner/mc_binary.rb
+++ b/lib/minio_runner/mc_binary.rb
@@ -13,6 +13,10 @@ module MinioRunner
         "https://dl.min.io/client/mc/release"
       end
 
+      def platform_binary_url
+        MinioRunner.config.mc_binary_download_url || "#{platform_base_url}#{name}"
+      end
+
       def platform_base_url
         if System.linux?
           "#{base_url}/linux-amd64/"

--- a/lib/minio_runner/minio_binary.rb
+++ b/lib/minio_runner/minio_binary.rb
@@ -14,7 +14,7 @@ module MinioRunner
       end
 
       def platform_binary_url
-        "#{platform_base_url}#{name}"
+        MinioRunner.config.minio_binary_download_url || "#{platform_base_url}#{name}"
       end
 
       def platform_sha256sum_url


### PR DESCRIPTION
Hello!

We are working on a discourse plugin, and using [this github action workflow](https://github.com/discourse/.github/blob/main/.github/workflows/discourse-plugin.yml) in our plugin's CI.

Currently the step "Ensure latest minio binary installed for Core System Tests" in our CI fails. This step calls `MinioRunner.install_binaries` and we get:

```
'MinioRunner::Network.get': Net::HTTPRetriableError: 302 "Found" with https://dl.min.io/client/mc/release/linux-amd64/mc.sha256sum (MinioRunner::Network::NetworkError)

...

D, [2026-04-23T14:17:04.709893 #2936] DEBUG -- : [MinioRunner]: Making network call to https://dl.min.io/client/mc/release/linux-amd64/mc.sha256sum
D, [2026-04-23T14:17:04.996614 #2936] DEBUG -- : [MinioRunner]: Get response: #<Net::HTTPFound 302 Found readbody=true>
Error: Process completed with exit code 1.
```

The minio_runner project doesn't have an "Issues" tab, and to be honest this is more of a bug report. Nonetheless, I thought I would come with some proposal: we could mitigate this problem by overriding download urls in the config, when running on our CI the url should be deterministic... but that might not be true for everyone. 

It's a temporary redirect though, maybe the solution is just to wait, but we haven't been able to merge our PRs today because of this. Do you have another idea? 
Cheers,
Agathe

Disclaimer: I didn't test my solution, just want to start the discussion :) 