### PR TITLE
FIX: Follow redirects when getting binaries

### DIFF
--- a/lib/minio_runner/network.rb
+++ b/lib/minio_runner/network.rb
@@ -20,8 +20,10 @@ module MinioRunner
       127.0.0.1 minio.local testbucket.minio.local
     END
 
+    MAX_REDIRECTS = 5
+
     class << self
-      def get(url)
+      def get(url, redirect_limit: MAX_REDIRECTS)
         MinioRunner.logger.debug("Making network call to #{url}")
         uri = URI(url)
         response = nil
@@ -33,7 +35,7 @@ module MinioRunner
             uri.port,
             use_ssl: uri.scheme == "https",
             open_timeout: MinioRunner::System.mac? ? 10 : 3,
-          ) { |http| response = http.get(uri.path) }
+          ) { |http| response = http.get(uri.request_uri) }
         rescue SocketError, Net::OpenTimeout => err
           MinioRunner.logger.debug(
             "Connection error when checking minio server health: #{err.message}",
@@ -50,6 +52,11 @@ module MinioRunner
         when Net::HTTPSuccess
           log_time_error(request_start_time)
           response.body
+        when Net::HTTPRedirection
+          raise MinioRunner::Network::NetworkError.new("Too many redirects for #{url}") if redirect_limit <= 0
+          location = response["location"]
+          MinioRunner.logger.debug("Following redirect to #{location}")
+          get(location, redirect_limit: redirect_limit - 1)
         else
           raise MinioRunner::Network::NetworkError.new(
                   "#{response.class::EXCEPTION_TYPE}: #{response.code} \"#{response.message}\" with #{url}",


### PR DESCRIPTION
```
#8 32.57 /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner/network.rb:54:in 'MinioRunner::Network.get': Net::HTTPRetriableError: 302 "Found" with https://dl.min.io/client/mc/release/linux-amd64/mc.sha256sum (MinioRunner::Network::NetworkError)
#8 32.57 	from /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner/network.rb:64:in 'block in MinioRunner::Network.download'
#8 32.57 	from /usr/local/lib/ruby/3.4.0/tempfile.rb:444:in 'Tempfile.open'
#8 32.57 	from /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner/network.rb:63:in 'MinioRunner::Network.download'
#8 32.57 	from /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner/binary_manager.rb:38:in 'MinioRunner::BinaryManager#new_version_available?'
#8 32.57 	from /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner/binary_manager.rb:21:in 'MinioRunner::BinaryManager#install'
#8 32.57 	from /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner/binary_manager.rb:9:in 'MinioRunner::BinaryManager.install'
#8 32.57 	from /var/www/discourse/vendor/bundle/ruby/3.4.0/gems/minio_runner-1.0.0/lib/minio_runner.rb:69:in 'MinioRunner.install_binaries'
#8 32.57 	from script/install_minio_binaries.rb:7:in '<main>'
#8 32.58 D, [2026-04-23T19:33:21.918853 #640] DEBUG -- : [MinioRunner]: Making network call to https://dl.min.io/client/mc/release/linux-amd64/mc.sha256sum
#8 32.58 D, [2026-04-23T19:33:22.261025 #640] DEBUG -- : [MinioRunner]: Get response: #<Net::HTTPFound 302 Found readbody=true>
#8 ERROR: process "/bin/sh -c sudo -EH -u discourse /custom-plugin-tests/prepare_base.sh" did not complete successfully: exit code: 1
------
```