### PR TITLE
DEV: Surface `mc` failures in `MinioRunner.start`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    minio_runner (1.0.1)
+    minio_runner (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/minio_runner/mc_manager.rb
+++ b/lib/minio_runner/mc_manager.rb
@@ -1,26 +1,29 @@
 # frozen_string_literal: true
 
+require "open3"
+
 module MinioRunner
   class McManager
+    CommandError = Class.new(StandardError)
+
+    DEFAULT_RETRIES = 5
+    RETRY_DELAY = 1
+
     class << self
       def command
         ["#{MinioRunner::McBinary.binary_file_path}"]
       end
 
       def bucket_exists?(alias_name, name)
-        system(
-          *command.concat(["ls", "#{alias_name}/#{name}"]),
-          out: MinioServerManager.log_file_path,
-        )
+        # `mc ls` exits non-zero when the bucket is missing, which is fine here.
+        _, _, status = run_mc(["ls", "#{alias_name}/#{name}"], allow_failure: true, retries: 0)
+        status.success?
       end
 
       def create_bucket(alias_name, name)
         MinioRunner.logger.debug("Creating bucket #{alias_name}/#{name}...")
         if !bucket_exists?(alias_name, name)
-          system(
-            *command.concat(["mb", "#{alias_name}/#{name}"]),
-            out: MinioServerManager.log_file_path,
-          )
+          run_mc(["mb", "#{alias_name}/#{name}"])
           MinioRunner.logger.debug("Created  #{alias_name}/#{name}.")
         else
           MinioRunner.logger.debug("Bucket #{alias_name}/#{name} already exists, doing nothing.")
@@ -29,18 +32,15 @@ module MinioRunner
 
       def set_alias(name, url)
         MinioRunner.logger.debug("Setting alias #{name} to #{url}...")
-        system(
-          *command.concat(
-            [
-              "alias",
-              "set",
-              name,
-              url,
-              MinioRunner.config.minio_root_user,
-              MinioRunner.config.minio_root_password,
-            ],
-          ),
-          out: MinioServerManager.log_file_path,
+        run_mc(
+          [
+            "alias",
+            "set",
+            name,
+            url,
+            MinioRunner.config.minio_root_user,
+            MinioRunner.config.minio_root_password,
+          ],
         )
         MinioRunner.logger.debug("Set alias #{name} to #{url}.")
       end
@@ -49,11 +49,39 @@ module MinioRunner
         MinioRunner.logger.debug(
           "Setting anonymous access for #{alias_name}/#{bucket} to policy #{policy}...",
         )
-        system(
-          *command.concat(["anonymous", "set", policy, "#{alias_name}/#{bucket}"]),
-          out: MinioServerManager.log_file_path,
-        )
+        run_mc(["anonymous", "set", policy, "#{alias_name}/#{bucket}"])
         MinioRunner.logger.debug("Anonymous access set for #{alias_name}/#{bucket}.")
+      end
+
+      # Captures stdout/stderr to the minio log file, retries with backoff
+      # on non-zero exit codes (covers errors like "Server not initialized yet"
+      # and "connection refused" when minio is still starting) and raises
+      # `CommandError` on actual failures. (unless `allow_failure` is set)
+      def run_mc(args, allow_failure: false, retries: DEFAULT_RETRIES)
+        full_command = command + args
+        max_attempts = retries + 1
+        attempts = 0
+        stdout = stderr = status = nil
+
+        while attempts < max_attempts
+          stdout, stderr, status = Open3.capture3(*full_command)
+          File.open(MinioServerManager.log_file_path, "a") { |f| f.write(stdout, stderr) }
+
+          attempts += 1
+          break if status.success? || attempts == max_attempts
+
+          MinioRunner.logger.warn(
+            "mc #{args.join(" ")} failed (attempt #{attempts}/#{max_attempts}, " \
+              "exit #{status.exitstatus}); retrying in #{RETRY_DELAY}s: #{stderr.strip}",
+          )
+          sleep(RETRY_DELAY)
+        end
+
+        return stdout, stderr, status if status.success? || allow_failure
+
+        raise CommandError,
+              "mc #{args.join(" ")} failed after #{attempts} attempts " \
+                "(exit #{status.exitstatus}): #{stderr.strip}"
       end
     end
   end

--- a/lib/minio_runner/minio_health_check.rb
+++ b/lib/minio_runner/minio_health_check.rb
@@ -8,8 +8,10 @@ module MinioRunner
   # Also used to check whether /etc/hosts is configured properly; some platforms
   # (read: macOS) have to be configured in a certain way to avoid this.
   class MinioHealthCheck
+    DEFAULT_RETRIES = 10
+
     class << self
-      def call(retries: 2, initial_retries: nil)
+      def call(retries: DEFAULT_RETRIES, initial_retries: nil)
         initial_retries ||= retries
         begin
           Network.get("#{MinioRunner.config.minio_server_url}/minio/health/live")

--- a/lib/minio_runner/minio_server_manager.rb
+++ b/lib/minio_runner/minio_server_manager.rb
@@ -48,7 +48,7 @@ module MinioRunner
       @process.start
 
       # Make sure the minio server is ready to accept requests.
-      MinioRunner::MinioHealthCheck.call(retries: 2)
+      MinioRunner::MinioHealthCheck.call
 
       MinioRunner.logger.debug("minio server running at pid #{@process.pid}!")
     end

--- a/lib/minio_runner/version.rb
+++ b/lib/minio_runner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MinioRunner
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/test/test_minio_runner_mc_manager.rb
+++ b/test/test_minio_runner_mc_manager.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+
+class TestMinioRunnerMcManager < Minitest::Test
+  def described_class
+    MinioRunner::McManager
+  end
+
+  def setup
+    MinioRunner.config.install_dir = "/tmp/minio_runner_test"
+    MinioRunner.remove_install_dir
+    MinioRunner::System.make_install_dir
+    Spy.on(described_class, :sleep).and_return(nil)
+  end
+
+  def teardown
+    Spy.teardown
+    MinioRunner.reset_config!
+  end
+
+  def stub_capture3(*responses)
+    queue = responses.dup
+    Spy.on(Open3, :capture3).and_return { queue.shift || responses.last }
+  end
+
+  def ok(stdout = "")
+    [stdout, "", make_status(true)]
+  end
+
+  def failed(stderr = "boom")
+    ["", stderr, make_status(false)]
+  end
+
+  def make_status(success)
+    Object.new.tap do |s|
+      s.define_singleton_method(:success?) { success }
+      s.define_singleton_method(:exitstatus) { success ? 0 : 1 }
+    end
+  end
+
+  def test_run_mc_returns_on_success
+    capture3 = stub_capture3(ok("hello"))
+
+    out, err, st = described_class.run_mc(%w[ls local])
+
+    assert_equal "hello", out
+    assert_equal "", err
+    assert st.success?
+    assert_equal 1, capture3.calls.size
+  end
+
+  def test_run_mc_retries_then_succeeds
+    capture3 = stub_capture3(failed("Server not initialized yet"), failed("connection refused"), ok)
+
+    described_class.run_mc(%w[alias set local http://x u p])
+
+    assert_equal 3, capture3.calls.size
+  end
+
+  def test_run_mc_raises_after_exhausting_retries
+    stub_capture3(failed)
+
+    assert_raises(MinioRunner::McManager::CommandError) do
+      described_class.run_mc(%w[mb local/x], retries: 2)
+    end
+  end
+
+  def test_run_mc_returns_status_when_allow_failure_is_true
+    stub_capture3(failed("no such bucket"))
+
+    _, _, st = described_class.run_mc(%w[ls local/missing], allow_failure: true, retries: 0)
+
+    refute st.success?
+  end
+
+  def test_bucket_exists_returns_false_without_raising_when_bucket_missing
+    stub_capture3(failed("Object does not exist"))
+
+    refute described_class.bucket_exists?("local", "missing")
+  end
+
+  def test_bucket_exists_returns_true_when_listing_succeeds
+    stub_capture3(ok("bucket contents"))
+
+    assert described_class.bucket_exists?("local", "present")
+  end
+
+  def test_set_alias_raises_on_persistent_failure
+    stub_capture3(failed("Server not initialized yet"))
+
+    assert_raises(MinioRunner::McManager::CommandError) do
+      described_class.set_alias("local", "http://localhost:9000")
+    end
+  end
+
+  def test_set_alias_recovers_after_transient_failure
+    capture3 = stub_capture3(failed("Server not initialized yet"), ok)
+
+    described_class.set_alias("local", "http://localhost:9000")
+
+    assert_equal 2, capture3.calls.size
+  end
+
+  def test_create_bucket_skips_when_bucket_exists
+    capture3 = stub_capture3(ok)
+
+    described_class.create_bucket("local", "existing")
+
+    assert_equal 1, capture3.calls.size
+    assert_includes capture3.calls.first.args, "ls"
+  end
+
+  def test_create_bucket_makes_bucket_when_missing
+    capture3 = stub_capture3(failed("Object does not exist"), ok)
+
+    described_class.create_bucket("local", "new-bucket")
+
+    assert_equal 2, capture3.calls.size
+    assert_includes capture3.calls.last.args, "mb"
+  end
+
+  def test_create_bucket_raises_when_mb_fails_persistently
+    stub_capture3(failed("Object does not exist"), failed)
+
+    assert_raises(MinioRunner::McManager::CommandError) do
+      described_class.create_bucket("local", "doomed")
+    end
+  end
+
+  def test_set_anon_raises_on_persistent_failure
+    stub_capture3(failed)
+
+    assert_raises(MinioRunner::McManager::CommandError) do
+      described_class.set_anon("local", "x", "public")
+    end
+  end
+end


### PR DESCRIPTION
`run_mc` now retries temporary `mc` failures and raises `CommandError` on persistent failure. (instead of silently returning)

Health-check default retries is increased from 2 to 10.